### PR TITLE
refactor(database): removed unnecessary/redundant code

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -338,11 +338,6 @@ exports.DatabaseAPI = function DatabaseAPI(hoodie, options) {
                 return memo;
             }, {});
 
-            // If no view exists by this name we initialise as empty object.
-            if (!ddoc.views[name]) {
-                ddoc.views[name] = {};
-            }
-
             // If view code has not changed we don't need to do anything else.
             // NOTE: Not sure if this is the best way to deal with this. This
             // saves work and avoids unnecessarily overwriting the


### PR DESCRIPTION
A bit of housekeeping... After reviewing my previous [PR](https://github.com/hoodiehq/hoodie-plugins-api/pull/40) I realised we do not need to initialise `ddoc.views[name]` as an empty object in `db.addIndex()` as we assign directly to it and not its members.

cc/ @svnlto
