### PR TITLE
feat(database): add parse option to db.query params

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -376,20 +376,33 @@ exports.DatabaseAPI = function DatabaseAPI(hoodie, options) {
 
     /**
      * Query a couchdb view on db
+     *
+     * Arguments:
+     *
+     * * `index` is the name of the view we want to query.
+     *
+     * * `params` is an object with view query parameters to be passed on when
+     * sending request to CouchDB. There is a special `params.parse` property
+     * that is not passed to CouchDB but used to know whether we should parse
+     * the values in the results as proper documents (translating couchdb's
+     * `_id` to hoodie's `id` and so on). If your view's map function emits
+     * whole documents as values you will probably want to use `params.parse` so
+     * that you get a nice array of docs as you would with `db.findAll()`.
      */
 
-    db.query = function (index, options, callback) {
-        // `options` is optional, when only two args passed second is callback.
+    db.query = function (index, params, callback) {
+        // `params` is optional, when only two args passed second is callback.
         if (arguments.length === 2) {
-            callback = options;
-            options = null;
+            callback = params;
+            params = null;
         }
 
         var view_url = db._resolve('_design/views/_view/' + index);
 
-        // If options have been passed we build the query string.
-        if (options) {
-            var qs = _.reduce(options, function (memo, v, k) {
+        // If params have been passed we build the query string.
+        if (params) {
+            var qs = _.reduce(params, function (memo, v, k) {
+                if (k === 'parse') { return memo; }
                 if (memo) { memo += '&'; }
                 return memo + k + '=' + encodeURIComponent(JSON.stringify(v));
             }, '');
@@ -402,7 +415,15 @@ exports.DatabaseAPI = function DatabaseAPI(hoodie, options) {
             if (err) {
                 return callback(err);
             }
-            callback(null, data.rows, _.omit(data, [ 'rows' ]));
+            var results = data.rows;
+            // If `params.parse` was set we need to parse the value in each row
+            // as a proper document.
+            if (params && params.parse) {
+                results = data.rows.map(function (r) {
+                    return options.parse(r.value);
+                });
+            }
+            callback(null, results, _.omit(data, [ 'rows' ]));
         });
     };
 


### PR DESCRIPTION
Works like:

``` js
var params = {
  descending: true,
  parse: true // this is the new param
};

db.query('by_something', params, function (err, docs, meta) {
  // `docs` is now an array of objects parsed just like you would get from
  // `db.findAll()` instead of the standard couchdb rows as they are returned
  // in the couchdb view results.
});
```
